### PR TITLE
Fix langchain agent conversation context

### DIFF
--- a/ai/agents/langchain_agent/explainer_agent.py
+++ b/ai/agents/langchain_agent/explainer_agent.py
@@ -686,6 +686,24 @@ class LangChainExplainerAgent:
         self.logger.info(f"  Include all sections: {self.include_all_sections}")
         self.logger.info(f"  Session logging: {self.enable_session_logging}")
 
+    def _build_history_prefix(self, max_messages: int = 8) -> str:
+        """Create a lightweight text prefix of recent conversation to reinforce context."""
+        try:
+            if not self.messages:
+                return ""
+            recent = self.messages[-max_messages:]
+            lines: List[str] = []
+            for m in recent:
+                if isinstance(m, HumanMessage):
+                    lines.append(f"User: {m.content}")
+                elif isinstance(m, AIMessage):
+                    lines.append(f"Assistant: {m.content}")
+            if not lines:
+                return ""
+            return "Previous conversation (most recent first):\n" + "\n".join(lines)
+        except Exception:
+            return ""
+
     def _make_json_serializable(self, obj):
         """Best-effort conversion to JSON-serializable objects."""
         try:
@@ -921,9 +939,13 @@ class LangChainExplainerAgent:
             
             self.add_message("user", prompt)
 
+            input_with_context = prompt
+            history_prefix = self._build_history_prefix()
+            if history_prefix:
+                input_with_context = f"{history_prefix}\n\nCurrent request: {prompt}"
             result = self.agent_executor.invoke(
                 {
-                    "input": prompt,
+                    "input": input_with_context,
                     "chat_history": self.messages[:-1] # Exclude current message
                 },
                 config={"callbacks": [execution_callback]}
@@ -1052,8 +1074,12 @@ class LangChainExplainerAgent:
                 
                 # Use astream_events but with better handling for Anthropic
                 event_count = 0
+                input_with_context = prompt
+                history_prefix = self._build_history_prefix()
+                if history_prefix:
+                    input_with_context = f"{history_prefix}\n\nCurrent request: {prompt}"
                 async for event in self.agent_executor.astream_events({
-                    "input": prompt,
+                    "input": input_with_context,
                     "chat_history": self.messages[:-1]
                 }, version="v1", config={"callbacks": [execution_callback]}):
                     event_count += 1
@@ -1392,8 +1418,12 @@ class LangChainExplainerAgent:
             # Use astream_events to get token and tool streaming with prompts and tools injected
             self.logger.info("Starting astream_events with agent executor")
             event_count = 0
+            input_with_context = prompt
+            history_prefix = self._build_history_prefix()
+            if history_prefix:
+                input_with_context = f"{history_prefix}\n\nCurrent request: {prompt}"
             async for event in self.agent_executor.astream_events({
-                "input": prompt,
+                "input": input_with_context,
                 "chat_history": self.messages[:-1]
             }, version="v1", config={"callbacks": [execution_callback]}):
                 event_count += 1

--- a/ai/routes/explainer_chat.py
+++ b/ai/routes/explainer_chat.py
@@ -297,15 +297,31 @@ async def langchain_explainer_streaming_api(request: Request):
         if not session_id:
             session_id = str(uuid.uuid4())
         session_key = f"langchain_{session_id}"
+        legacy_key = session_id
         
-        if session_key in explainer_sessions:
-            agent = explainer_sessions[session_key]
+        if session_key in explainer_sessions or legacy_key in explainer_sessions:
+            agent = explainer_sessions.get(session_key) or explainer_sessions.get(legacy_key)
+            # If legacy key found, move it to session_key for consistency
+            if legacy_key in explainer_sessions and session_key not in explainer_sessions:
+                explainer_sessions[session_key] = explainer_sessions.pop(legacy_key)
             # Update agent configuration if needed
             if hasattr(agent, 'model_key') and agent.model_key != model_key:
-                agent = create_explainer_agent(model_key=model_key, tool_groups=tool_group_enums, enable_session_logging=True)
+                # Preserve conversation history when switching models
+                old_messages = getattr(agent, 'messages', [])
+                new_agent = create_explainer_agent(
+                    model_key=model_key,
+                    tool_groups=tool_group_enums,
+                    enable_session_logging=True
+                )
+                # Carry over prior messages so chat history is preserved
+                setattr(new_agent, 'messages', old_messages)
+                agent = new_agent
                 explainer_sessions[session_key] = agent
-            elif hasattr(agent, 'tool_groups') and agent.tool_groups != tool_group_enums:
-                agent.update_tool_groups(tool_groups)
+                logger.info("Recreated agent with new model and preserved message history")
+            elif hasattr(agent, 'tool_groups') and set(getattr(agent, 'tool_groups', [])) != set(tool_group_enums):
+                # Update tools in place; this keeps existing message history
+                agent.update_tool_groups(tool_group_enums)
+                logger.info("Updated agent tool groups in place without losing history")
             logger.info(f"Using existing LangChain explainer agent for session: {session_key}")
         else:
             # Create new LangChain agent and session with session logging enabled
@@ -490,8 +506,16 @@ async def clear_explainer_session(request: Request):
                 }
             )
         
+        # Support both prefixed and legacy keys
+        session_key = f"langchain_{session_id}"
+        removed = False
+        if session_key in explainer_sessions:
+            del explainer_sessions[session_key]
+            removed = True
         if session_id in explainer_sessions:
             del explainer_sessions[session_id]
+            removed = True
+        if removed:
             logger.info(f"Cleared explainer session: {session_id}")
             return JSONResponse(content={"status": "success", "message": f"Session {session_id} cleared"})
         else:


### PR DESCRIPTION
Preserve LangChain agent conversation context by explicitly carrying over chat history during agent recreation and reinforcing recent messages in the prompt.

The agent was losing context because its internal `messages` were not consistently maintained across session updates (e.g., model changes) and because the `chat_history` parameter alone wasn't always sufficient for the agent to retain context, especially during tool calls. This PR addresses both by ensuring history is preserved during agent lifecycle events and by prepending a summary of recent messages to the agent's input.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b8327f4-7d7a-455b-bd00-39490655265a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b8327f4-7d7a-455b-bd00-39490655265a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

