### PR TITLE
Fix metric 98 dashboard data display

### DIFF
--- a/ai/tools/gcs_storage.py
+++ b/ai/tools/gcs_storage.py
@@ -196,11 +196,21 @@ class GCSStorageManager:
             if self.gcs_enabled:
                 gcs_path = self._get_gcs_path(file_type, district, metric_id, filename)
                 blob = self.bucket.blob(gcs_path)
-                
+                # Reduce cache staleness for dynamic dashboard assets
+                if file_type in ["dashboard"]:
+                    blob.cache_control = "no-cache, no-store, must-revalidate, max-age=0"
+                # Ensure correct content type is set
                 blob.upload_from_string(
                     content_bytes,
                     content_type=content_type
                 )
+                # Persist cache-control metadata if set
+                try:
+                    if blob.cache_control:
+                        blob.patch()
+                except Exception:
+                    # Best effort; do not fail storing due to metadata update
+                    pass
                 
                 logger.info(f"Successfully stored file in GCS: {gcs_path}")
                 return True

--- a/nginx_transparentsf.conf
+++ b/nginx_transparentsf.conf
@@ -88,6 +88,13 @@ server {
     # Output files
     location /output/ {
         alias /opt/transparentsf/ai/output/;
+        # Dashboard JSON should not be cached by CDN/browsers to avoid staleness
+        location ~* ^/output/dashboard/.*\.json$ {
+            expires -1;
+            add_header Cache-Control "no-cache, no-store, must-revalidate, max-age=0" always;
+            try_files $uri =404;
+        }
+        # Default: allow caching for other outputs (e.g., reports)
         expires 1d;
         add_header Cache-Control "public";
     }


### PR DESCRIPTION
Set `no-cache` headers for dashboard JSON files in GCS and Nginx to prevent stale data from being displayed.

The dashboard was showing outdated data for metric 98 because the JSON files were being aggressively cached by Nginx and potentially CDNs/browsers, even after new data was generated. This change ensures that the latest data is always fetched and displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-539e4bfe-6cb2-4648-9922-485b91f2094d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-539e4bfe-6cb2-4648-9922-485b91f2094d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

